### PR TITLE
Health planetの体組成データをfitbitに転送する処理の追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def main(event, context) -> None:
 
 
 def run(prj: Union[None, str] = None) -> None:
-    '''実行日の前日の健康データを各APIから取得しgcsへ保存する(ローカル環境で実行する場合はこちら)
+    '''実行日の前日の健康データを各APIから取得・更新しgcsへデータを保存する(ローカル環境で実行する場合はこちら)
 
     Args:
         prj (Union[None, str], optional): 関数を実行する環境，未入力(None)ならばローカルとする.
@@ -128,6 +128,21 @@ def run(prj: Union[None, str] = None) -> None:
             os.remove(fb_path)
         except Exception:
             print(traceback.format_exc())
+
+    # Fitbitに体組成データの転送
+    body_compositions_data = body_compositions['data']
+    if len(body_compositions_data) > 0:
+        for i in body_compositions_data:
+            created_datetime = pd.to_datetime(i['date']).strftime('%Y-%m-%d %H:%M')
+            splited_created_datetime = created_datetime.split(' ')
+            fb.create_body_log(
+                body_type='weight' if i['tag'] == '6021' else 'fat',
+                value=float(i['keydata']),
+                created_date=splited_created_datetime[0],
+                created_time=splited_created_datetime[1] + ':00'
+            )
+    else:
+        print('body compositions is empty.')
 
 
 if __name__ == '__main__':

--- a/src/fitbit.py
+++ b/src/fitbit.py
@@ -69,6 +69,30 @@ class Fitbit:
         # 辞書型で出力
         return json.loads(body.decode('utf-8'))
 
+    def refresh_access_token(self) -> None:
+        '''refresh_token経由でaccess_tokenとrefresh_tokenを更新する
+        '''
+        basic_user_and_pasword = base64.b64encode('{}:{}'.format(self.client_id, self.client_secret).encode('utf-8'))
+        url = 'https://api.fitbit.com/oauth2/token'
+        data = {
+            'grant_type': 'refresh_token',
+            'refresh_token': self.refresh_token
+        }
+        headers = {
+            'Authorization': 'Basic ' + basic_user_and_pasword.decode('utf-8'),
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+        req = urllib.request.Request(url, data=urllib.parse.urlencode(data).encode(), headers=headers)
+        try:
+            with urllib.request.urlopen(req) as res:
+                body = res.read()
+        except urllib.error.HTTPError as e:
+            print('Isnt the refresh token expired? Try method "fetch_authorization_code" & "fetch_tokens".')
+            raise e
+        res_dict = eval(body.decode('utf-8'))
+        self.access_token = res_dict['access_token']
+        self.refresh_token = res_dict['refresh_token']
+
     def fetch_tokens(
         self,
         redirect_uri: str = 'http://localhost:8080',
@@ -105,30 +129,6 @@ class Fitbit:
                 body = res.read()
         except urllib.error.HTTPError as e:
             print('Isnt the authorization code expired? Try method "fetch_authorization_code".')
-            raise e
-        res_dict = eval(body.decode('utf-8'))
-        self.access_token = res_dict['access_token']
-        self.refresh_token = res_dict['refresh_token']
-
-    def refresh_access_token(self) -> None:
-        '''refresh_token経由でaccess_tokenとrefresh_tokenを更新する
-        '''
-        basic_user_and_pasword = base64.b64encode('{}:{}'.format(self.client_id, self.client_secret).encode('utf-8'))
-        url = 'https://api.fitbit.com/oauth2/token'
-        data = {
-            'grant_type': 'refresh_token',
-            'refresh_token': self.refresh_token
-        }
-        headers = {
-            'Authorization': 'Basic ' + basic_user_and_pasword.decode('utf-8'),
-            'Content-Type': 'application/x-www-form-urlencoded',
-        }
-        req = urllib.request.Request(url, data=urllib.parse.urlencode(data).encode(), headers=headers)
-        try:
-            with urllib.request.urlopen(req) as res:
-                body = res.read()
-        except urllib.error.HTTPError as e:
-            print('Isnt the refresh token expired? Try method "fetch_authorization_code" & "fetch_tokens".')
             raise e
         res_dict = eval(body.decode('utf-8'))
         self.access_token = res_dict['access_token']

--- a/src/fitbit.py
+++ b/src/fitbit.py
@@ -69,6 +69,73 @@ class Fitbit:
         # 辞書型で出力
         return json.loads(body.decode('utf-8'))
 
+    def create_body_log(
+        self,
+        body_type: str,
+        value: float,
+        created_date: str,
+        created_time: str
+    ) -> Dict[Any, Any]:
+        '''指定した体組成の値をfitbitに記録する
+
+        Args:
+            body_type (str): 記録したい体組成を指定する, "weight"または"fat"のいずれかを入力
+            value (float): body_typeにて指定した体組成の値
+            created_date (str): 体重が記録された日付, yyyy-MM-dd
+            created_time (str): 体重が記録された時間, HH:mm:ss
+
+        Returns:
+            Dict[Any, Any]: fitbitに記録したデータ
+        '''
+        # 引数body_typeの値確認
+        if type(body_type) == str:
+            if body_type not in ['weight', 'fat']:
+                raise ValueError('Please input "weight" or "fat".')
+        else:
+            raise TypeError('"body_type" type must be str.')
+
+        # 引数valueの値確認
+        if type(value) == float:
+            if value < 0:
+                raise ValueError('"value" must be over 0.')
+        else:
+            raise TypeError('"value" type must be float or int.')
+
+        # 引数created_dateの型確認
+        if type(created_date) != str:
+            raise TypeError('"created_date" type must be str.')
+
+        # created_dateのフォーマット確認
+        if not re.search(r'^20[0-9]{2}-[0-1][0-9]-[0-3][0-9]$', created_date):
+            raise ValueError('"created_date" must be yyyy-MM-dd.')
+
+        # 引数created_timeの型確認
+        if type(created_time) != str:
+            raise TypeError('"created_time" type must be str.')
+
+        # created_timeのフォーマット確認
+        if not re.search(r'^[0-2][0-9]:[0-6][0-9]:[0-6][0-9]$', created_time):
+            raise ValueError('"created_time" must be HH:mm:ss.')
+
+        # 該当データを記録
+        headers = {'authorization': 'Bearer ' + self.access_token}
+        data = {
+            body_type: value,
+            'date': created_date,
+            'time': created_time
+        }
+        url = 'https://api.fitbit.com/1/user/-/body/log/{}.json'.format(body_type)
+        req = urllib.request.Request(url, headers=headers, data=urllib.parse.urlencode(data).encode())
+        try:
+            with urllib.request.urlopen(req) as res:
+                body = res.read()
+        except urllib.error.HTTPError as e:
+            print('Isnt the access token expired?  Try method "refresh_access_token".')
+            raise e
+
+        # 辞書型で出力
+        return json.loads(body.decode('utf-8'))
+
     def refresh_access_token(self) -> None:
         '''refresh_token経由でaccess_tokenとrefresh_tokenを更新する
         '''
@@ -136,7 +203,7 @@ class Fitbit:
 
     def fetch_authorization_code(
         self,
-        scope: List[str] = ['activity', 'heartrate', 'nutrition', 'sleep'],
+        scope: List[str] = ['activity', 'heartrate', 'location', 'nutrition', 'profile', 'settings', 'sleep', 'social', 'weight'],
         expiers_in: int = 604800,
         redirect_uri: str = 'http://localhost:8080',
     ):
@@ -201,10 +268,10 @@ if __name__ == '__main__':
         access_token=access_token,
         refresh_token=refresh_token
     )
+
     for ctg in ['activities', 'foods', 'sleep']:
         try:
             result = fb.fetch_trace_data(ctg, t)
-            print('success: {}'.format(ctg))
         except urllib.error.HTTPError:
             try:
                 fb.refresh_access_token()
@@ -216,4 +283,9 @@ if __name__ == '__main__':
             with open(path, 'w') as f:
                 config_ini.write(f)
             result = fb.fetch_trace_data(ctg, t)
-            print('success: {}'.format(ctg))
+        print('success: {}'.format(ctg))
+
+    # fat = fb.create_body_log('fat', 25.6, '2021-11-01', '10:00:00')
+    # pprint.pprint(fat)
+    # weight = fb.create_body_log('weight', 85.0, '2021-11-01', '10:00:00')
+    # pprint.pprint(weight)

--- a/src/health_planet.py
+++ b/src/health_planet.py
@@ -13,7 +13,7 @@ from pandas.tseries.offsets import DateOffset
 class HealthPlanet:
     access_token: str
 
-    def fetch_body_composition_data(self, from_date: str, to_date: str) -> Dict[Any, Any]:
+    def fetch_body_composition_data(self, from_date: str, to_date: str) -> Dict[str, Any]:
         '''体重と体脂肪率を取得し辞書型で取得する
 
         Args:
@@ -21,7 +21,7 @@ class HealthPlanet:
             to_date (str): データを取得したい期間の終了日、"yyyy-mm-dd"形式で入力
 
         Returns:
-            Dict[Any, Any]: 体組成データ
+            Dict[str, Any]: 体組成データ
         '''
         # 引数from_dateの型確認
         if type(from_date) != str:
@@ -51,7 +51,6 @@ class HealthPlanet:
             raise ValueError('"from_date" is over 3 month ago.')
 
         # 該当データを取得
-        # データが存在しない時はExceptionを返す
         params = {
             'access_token': self.access_token,
             'data': '1',
@@ -63,23 +62,20 @@ class HealthPlanet:
         url = 'https://www.healthplanet.jp/status/innerscan.json/?' + p
         with urllib.request.urlopen(url) as res:
             result = res.read()
-        result_dic = json.loads(result)
-        data = result_dic['data']
-        # if len(data) == 0:
-        #     raise Exception('fetched data is empty')
-        return data
+        return json.loads(result)
 
 
 if __name__ == '__main__':
     # 以下，ローカル環境で動作検証時に使用
     import configparser
+    import pprint
 
     ini_path = 'local.ini'
     config_ini = configparser.ConfigParser()
     config_ini.read(ini_path, encoding='utf-8')
     access_token = config_ini.get('HEALTH PLANET', 'access-token')
 
-    d = '2021-09-28'
+    d = '2021-11-01'
     hp = HealthPlanet(access_token)
-    result = hp.fetch_body_composition_data(d, d)[0]
-    print(result)
+    result = hp.fetch_body_composition_data(d, d)
+    pprint.pprint(result)

--- a/tests/test_fitbit.py
+++ b/tests/test_fitbit.py
@@ -289,3 +289,99 @@ class TestFetchTraceData:
         '''検証が正しい: 指定した日にちの"sleep"データを取得する
         '''
         pass
+
+
+# TODO: access_tokenが不正の場合にErrorを返すmockの作成方法
+# TODO: データを書き込む系のAPIの検証方法
+class TestCreateBodyLog:
+    '''
+    - 異常系
+        - body_typeに文字列以外の型が与えられる
+        - body_typeにて"fat", "weight"以外の値が与えられる
+        - valueにfloat以外の型が与えられる
+        - valueに異常な値(0未満)が与えられる
+        - created_dateに文字列以外の型が与えられる
+        - created_dateが文字列であるが指定したフォーマットに従っていない
+        - created_timeに文字列以外の型が与えられる
+        - created_timeが文字列であるが指定したフォーマットに従っていない
+        - 生成したtokenにweightのアクセス権限が付与されていない
+        - access_tokenの期限切れ
+    - 正常系:
+        - 指定した日時の"weight"が入力される
+        - 指定した日時の"fat"が入力される
+    '''
+    def setup_method(self, method):
+        self.fake_client_id = 'fake_client_id'
+        self.fake_client_secret = 'fake_client_secret'
+        self.denied_access_token = 'denied_access_token'
+        self.expierd_access_token = 'expired_access_token'
+        self.fake_access_token = 'fake_access_token'
+
+    def test_invalid_body_type_not_string(self):
+        '''検証が正しくない: body_typeに文字列以外の型が与えられる
+        '''
+        pass
+
+    def test_invalid_body_type_not_abide_by_format(self):
+        '''検証が正しくない: body_typeにて"fat", "weight"以外の値が与えられる
+        '''
+        pass
+
+    def test_invalid_value_not_float(self):
+        '''検証が正しくない: valueにfloat以外の型が与えられる
+        '''
+        pass
+
+    def test_invalid_value_leq_zero(self):
+        '''検証が正しくない: valueに異常な値(0未満)が与えられる
+        '''
+        pass
+
+    def test_invalid_created_date_not_string(self):
+        '''検証が正しくない: created_dateに文字列以外の型が与えられる
+        '''
+        pass
+
+    def test_invalid_creatd_date_not_abide_by_format(self):
+        '''検証が正しくない: created_dateにて"fat", "weight"以外の値が与えられる
+        '''
+        pass
+
+    def test_invalid_created_time_not_string(self):
+        '''検証が正しくない: created_dateに文字列以外の型が与えられる
+        '''
+        pass
+
+    def test_invalid_creatd_time_not_abide_by_format(self):
+        '''検証が正しくない: created_dateにて"fat", "weight"以外の値が与えられる
+        '''
+        pass
+
+    @pytest.mark.skip('これまで抜けていた観点, 今後検証する必要あり')
+    def test_invalid_permission_denied(self):
+        '''検証が正しくない: 生成したtokenにprofileのアクセス権限が付与されていない
+        '''
+        pass
+
+    def test_invalid_access_token_epierd(self):
+        '''検証が正しくない: access_tokenの期限切れ
+        '''
+        fake_body_type = 'fat'
+        fake_value = 25.1
+        fake_date = '2021-11-01'
+        fake_time = '13:00:01'
+        fb = Fitbit(
+            client_id=self.fake_client_id,
+            client_secret=self.fake_client_secret,
+            access_token=self.expierd_access_token
+        )
+        with pytest.raises(urllib.error.HTTPError, match='HTTP Error 401: Unauthorized'):
+            fb.create_body_log(
+                fake_body_type, fake_value, fake_date, fake_time
+            )
+
+    @pytest.mark.skip('mockが作成できていないため')
+    def test_valid(self):
+        '''検証が正しい: プロフィールが格納された辞書型のデータを取得する
+        '''
+        pass


### PR DESCRIPTION
# Issue
- #1

# 背景
- Issueにあるように消費カロリーの計算には体重が必要であるため，Health Planetの計測した体組成データをfitbitに転送し同期させる必要がある

# 対応
- `src/fitbit.py`に体組成データをfitbitに転送するメソッドを追加
- Health Planetから取得したデータを整形する必要があるため，`fetch_body_composition_data`メソッドの出力形式を修正
- `main.py`にデータ取得後，fitbitに体組成データを転送する処理を追加