### PR TITLE
リングフィットアドベンチャーの実績画像をTwitter経由で取得しGCSへ転送する

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,8 +17,14 @@ node_modules
 #!include:.gitignore
 
 # dieter
+*.ini
 RAEDME.md
 poetry.lock
 pyproject.toml
 .vscode/*
 tests/*
+data/health_planet/*
+data/fitbit/activities/*
+data/fitbit/foods/*
+data/fitbit/sleep/*
+data/ring_fit_adventure/*

--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,6 @@ dmypy.json
 
 # dieter
 *.ini
+*.jpg
 data/**/*.json
 .DS_Store

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ def run(prj: Union[None, str] = None) -> None:
         os.makedirs('/tmp/data/fitbit/activities/', exist_ok=True)
         os.makedirs('/tmp/data/fitbit/foods/', exist_ok=True)
         os.makedirs('/tmp/data/fitbit/sleep/', exist_ok=True)
-        os.makedirs('/tmp/data/ringfitadventure/', exist_ok=True)
+        os.makedirs('/tmp/data/ring_fit_adventure/', exist_ok=True)
 
     # secret managerから値を取得
     if prj is None:

--- a/src/twitter.py
+++ b/src/twitter.py
@@ -1,0 +1,76 @@
+import json
+import re
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import List
+
+import pandas as pd
+from pandas.tseries.offsets import DateOffset
+
+
+@dataclass
+class Twitter:
+    user_id: str
+    bearer_token: str
+
+    def search_ringfitadventure_results(self, start_date: str) -> List[str]:
+        '''リングフィット実績画像のurlをリストで返す
+
+        Args:
+            start_date (str): 検索する時に遡る日付, YYYY-mm-dd, 最大７日まで遡ることが可能
+
+        Returns:
+            List[str]: リングフィットの実績画像のurlをまとめたリスト
+        '''
+        # 引数dateの型確認
+        if type(start_date) != str:
+            raise TypeError('"start_date" type must be str.')
+
+        # dateのフォーマット確認
+        if not re.search(r'^20[0-9]{2}-[0-1][0-9]-[0-3][0-9]$', start_date):
+            raise ValueError('"start_date" must be yyyy-mm-dd.')
+
+        # 日付が現時点よりも７日以上前でないことを確認
+        datetime = pd.to_datetime(start_date).tz_localize('Asia/Tokyo')
+        if datetime < (pd.Timestamp.today(tz='Asia/Tokyo') - DateOffset(days=7)):
+            raise ValueError('this method can search tweets from the last seven days')
+
+        # #RingFitAdventureのタグがついたツイートを検索する
+        headers = {
+            'Authorization': 'Bearer ' + self.bearer_token
+        }
+        query = 'from:{} #RingFitAdventure'.format(self.user_id)
+        params = {
+            'query': query,
+            'expansions': 'attachments.media_keys',
+            'media.fields': 'url',
+            'start_time': datetime.tz_convert('UTC').strftime('%Y-%m-%dT%H:%M:%SZ')
+        }
+        p = urllib.parse.urlencode(params, safe='', quote_via=urllib.parse.quote)
+        url = 'https://api.twitter.com/2/tweets/search/recent?' + p
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as res:
+            body = res.read()
+
+        # リングフィットの実績画像のurlをリストにまとめて出力
+        tweets = json.loads(body.decode('utf-8'))
+        try:
+            medias = tweets['includes']['media']
+            return [m['url'] for m in medias]
+        except KeyError:
+            print('tweets dont be have medias.')
+            return []
+
+
+if __name__ == '__main__':
+    import configparser
+
+    date = '2021-11-24'
+    ini_path = 'local.ini'
+    config_ini = configparser.ConfigParser()
+    config_ini.read(ini_path)
+    user_id = config_ini.get('TWITTER', 'user-id')
+    token = config_ini.get('TWITTER', 'escaped-bearer-token')
+    tw = Twitter(user_id, token)
+    print(tw.search_ringfitadventure_results(date))

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -1,0 +1,71 @@
+import pytest
+from src.twitter import Twitter
+
+
+class TestSearchRingfitadventureResults:
+    '''画像のURLをまとめたリストを取得できるか検証
+    - 異常系
+        - dateが文字列以外で与えられている
+        - dateが文字列であるが指定したフォーマットに従っていない
+        - dateが実行時よりも7日以上前が与えられている
+        - bearer_tokenが不適切
+    - 正常系:
+        - urlが格納されたリストが出力される
+        - 検索条件では画像が添付されておらず空のリストが出力される
+    '''
+    def setup_method(self, method):
+        '''各テストで共通して使用する変数を設定する
+        '''
+        self.fake_user_id = 'fake_user_id'
+        self.fake_token = 'fake_token'
+
+    def test_invalid_start_date_not_string(self):
+        '''検証が正しくない: dateが文字列であるが文字列以外で与えられている
+        '''
+        # 準備
+        bad_start_date = 20211108
+
+        # 実行・検証
+        tw = Twitter(self.fake_user_id, self.fake_token)
+        with pytest.raises(TypeError, match='"start_date" type must be str.'):
+            tw.search_ringfitadventure_results(bad_start_date)
+
+    def test_invalid_start_date_not_abide_by_format(self):
+        '''検証が正しくない: dateが指定したフォーマットに従っていない
+        '''
+        # 準備
+        bad_start_date = '20211108'
+
+        # 実行・検証
+        tw = Twitter(self.fake_user_id, self.fake_token)
+        with pytest.raises(ValueError, match='"start_date" must be yyyy-mm-dd.'):
+            tw.search_ringfitadventure_results(bad_start_date)
+
+    def test_invalid_start_date_goes_back_more_than_7days(self):
+        '''検証が正しくない: dateが実行時よりも7日以上前が与えられている
+        '''
+        # 準備
+        bad_start_date = '2021-11-08'
+
+        # 実行・検証
+        tw = Twitter(self.fake_user_id, self.fake_token)
+        with pytest.raises(ValueError, match='this method can search tweets from the last seven days'):
+            tw.search_ringfitadventure_results(bad_start_date)
+
+    @pytest.mark.skip('mockが作成できていないため')
+    def test_invalid_bad_bearer_token(self):
+        '''検証が正しくない: bearer_tokenが不適切
+        '''
+        pass
+
+    @pytest.mark.skip('mockが作成できていないため')
+    def test_valid(self):
+        '''検証が正しい: urlが格納されたリストが出力される
+        '''
+        pass
+
+    @pytest.mark.skip('mockが作成できていないため')
+    def test_valid_empty(self):
+        '''検索条件では画像が添付されておらず空のリストが出力される
+        '''
+        pass


### PR DESCRIPTION
# Issue
- #3 

# 背景
- Switchで2種類のフィットネス系ゲームをプレイしており，これらの運動結果のスクリーンショットを他の身体データ(Fitbit, Health Planet)と同じ場所(GCS)にまとめ管理したい
- ２種類のゲームの内，フィットボクシングはFitbitにてエアロビクスとして計測されるため，それをそのまま実績とする
- もう一つのリングフィットはFitbitに運動として判断されていないため，これを収集対象とする

# 対応
- リングフィットの実績画像を保存する場所をローカル，クラウド(GCS)双方に用意
- `src/twitter.py`にリングフィットの実績画像のurlを取得するメソッドを作成
- `main.py`に上記メソッドで取得したurlから画像をダウンロードしGCSへ転送する処理を追記